### PR TITLE
Lowercase sirupsen/logrus package

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Simple Logger Facade for Golang, inspired by SLF4J
 
 # What is SLF4GO
 
-SLF4GO is not a logger framework like logrus, it doesn't have better logger implement. 
+SLF4GO is not a logger framework like logrus, it doesn't have better logger implement.
 
 But SLF4GO could be used for separating your business code from logger framework.
 
@@ -13,13 +13,13 @@ SLF4GO provides two interface, named `Logger` and `LoggerFactory`.
 
 `LoggerFactory` used for adapting your logger framework.
 
-`Logger` used as log operation standard API, like `Trace`, `Debug`, `Info`, `Warn`, `Error`, 
+`Logger` used as log operation standard API, like `Trace`, `Debug`, `Info`, `Warn`, `Error`,
 all log methods of your logger framework need be wrapped by `Logger`.
 
 SLF4GO support logrus/log by default, you can use them directly.
 
-After above steps, 
-You can customize any logger framework as your what, 
+After above steps,
+You can customize any logger framework as your what,
 and then you need adapt it as a `LoggerFactory`, make it as the global LoggerFactory by `slf4go.SetLoggerFactory`.
 
 # Usage
@@ -69,7 +69,7 @@ func Login() {
 package main
 
 import (
-    log "github.com/Sirupsen/logrus"
+    log "github.com/sirupsen/logrus"
     "os"
     "github.com/sisyphsu/slf4go"
     "github.com/sisyphsu/slf4go/adapter/logrus"
@@ -102,7 +102,7 @@ As we can see, golang changes very quickly, and the logger-tech isn't very matur
 
 Separate the logger implement from modules maybe a good idea.
 
-if oneday you need to use `logxxx` replace `logrus`, 
+if oneday you need to use `logxxx` replace `logrus`,
 do you want to change all code contains `log.info(...)`?
-   
+
 or only change `logger_init.go`?

--- a/adaptor/logrus/logger_adaptor_logrus.go
+++ b/adaptor/logrus/logger_adaptor_logrus.go
@@ -1,7 +1,7 @@
 package logrus
 
 import (
-    log "github.com/Sirupsen/logrus"
+    log "github.com/sirupsen/logrus"
     "github.com/sisyphsu/slf4go"
 )
 

--- a/adaptor/logrus/logger_adaptor_logrus_test.go
+++ b/adaptor/logrus/logger_adaptor_logrus_test.go
@@ -3,7 +3,7 @@ package logrus
 import (
     "testing"
     "github.com/sisyphsu/slf4go"
-    log "github.com/Sirupsen/logrus"
+    log "github.com/sirupsen/logrus"
     "os"
 )
 
@@ -17,9 +17,9 @@ func TestGetLogrusLogger(t *testing.T) {
     // use defined logger factory
     l := log.New()
     l.WriterLevel(log.DebugLevel)
-    
+
     slf4go.SetLoggerFactory(NewLogrusLoggerFactory(l))
-    
+
     // do test
     logger := slf4go.GetLogger("test")
     logger.SetLevel(slf4go.LEVEL_TRACE)

--- a/example/logrus.go
+++ b/example/logrus.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-    log "github.com/Sirupsen/logrus"
+    log "github.com/sirupsen/logrus"
     "os"
     "github.com/sisyphsu/slf4go"
     "github.com/sisyphsu/slf4go/example/modules"


### PR DESCRIPTION
`go mod vendor` will fail with error
```
go: github.com/Sirupsen/logrus@v1.1.1: parsing go.mod: unexpected module path "github.com/sirupsen/logrus"
```
if the package name is in upper case. The convention seems to be lower case.