### PR TITLE
fix globaldriver cached bug

### DIFF
--- a/slf_core.go
+++ b/slf_core.go
@@ -50,6 +50,9 @@ func GetContext() string {
 func SetDriver(d Driver) {
 	globalDriver = d
 }
+func GetDriver() Driver {
+	return globalDriver
+}
 
 // SetLevel update the global level, all lower level will not be send to driver to print
 func SetLevel(l Level) {

--- a/slf_logger.go
+++ b/slf_logger.go
@@ -233,7 +233,7 @@ func (l *Logger) print(level Level, pc uintptr, stack *string, v ...interface{})
 		log.Logger = *l.name
 	}
 	globalHook.broadcast(log)
-	globalDriver.Print(log)
+	GetDriver().Print(log)
 }
 
 // do printf


### PR DESCRIPTION
when logger  call print function, the globalDriver sometimes maybe cached by the compiler, when i use SetDriver(&zapDriver) to set driver successful, but i call logger.Debug("test"), logger still use the "default" driver.