### PR TITLE
New logger

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/go-eden/slf4go
+module github.com/phenix3443/slf4go
 
 go 1.13
 

--- a/slf_logger.go
+++ b/slf_logger.go
@@ -1,6 +1,7 @@
 package slog
 
 import (
+	"fmt"
 	"runtime"
 	"runtime/debug"
 	"sync"
@@ -42,7 +43,8 @@ func (l *Logger) BindFields(fields Fields) {
 func (l *Logger) WithFields(fields Fields) *Logger {
 	l.mut.Lock()
 	defer l.mut.Unlock()
-	result := newLogger(l.name)
+	newLoggerName := fmt.Sprintf("%s_w", *l.name)
+	result := newLogger(&newLoggerName)
 	result.BindFields(NewFields(l.fields, fields))
 	return result
 }


### PR DESCRIPTION
new logger generated by logger.With() function should not use the same name with the previous logger, in this way, the slf4go-zap driver can cache different loggers by their name.